### PR TITLE
feat: ussd message length counter

### DIFF
--- a/lib/ussd.js
+++ b/lib/ussd.js
@@ -281,8 +281,9 @@ module.exports = function(params) {
                             }
                         };
                         parser.onend = function() {
+                            var shortMessageLength = config.charsCount ? '<br>[' + shortMessage.length + ']' : '';
                             resolve({
-                                shortMessage: shortMessage,
+                                shortMessage: shortMessage + shortMessageLength,
                                 sourceAddr: data.system.phone
                             });
                         };


### PR DESCRIPTION
This feature is intended to be used in dev and test environments to
ease identifying ussd messages that need either paging or shortening.